### PR TITLE
[FIX] Crash when [locations count] == 1

### DIFF
--- a/MoonRunner/Controller/MathController.m
+++ b/MoonRunner/Controller/MathController.m
@@ -113,6 +113,19 @@ static const int idealSmoothReachSize = 33; // about 133 locations/mi
 
 + (NSArray *)colorSegmentsForLocations:(NSArray *)locations
 {
+    if (locations.count == 1){
+        Location *loc      = [locations firstObject];
+        CLLocationCoordinate2D coords[2];
+        coords[0].latitude      = loc.latitude.doubleValue;
+        coords[0].longitude     = loc.longitude.doubleValue;
+        coords[1].latitude      = loc.latitude.doubleValue;
+        coords[1].longitude     = loc.longitude.doubleValue;
+        
+        MulticolorPolylineSegment *segment = [MulticolorPolylineSegment polylineWithCoordinates:coords count:2];
+        segment.color = [UIColor blackColor];
+        return @[segment];
+    }    
+    
     // make array of all speeds, find slowest+fastest
     NSMutableArray *rawSpeeds = [NSMutableArray array];
     double slowestSpeed = DBL_MAX;


### PR DESCRIPTION
Hello !
Thanks for the two-part RW tutorial, I kept me awaken until past midnight yesterday :)

Following the comments on part 1, I downloaded your smooth color method for the run. Sometimes, when the run is finished just after it was started, the array of locations contains only one element.

In colorSegmentsForLocations: method, then rawSpeeds array stays empty, so as smoothSpeeds, sortedArray, and the crash occurs when we try to get the medianSpeed from it.
