### PR TITLE
change abs() to fabs() to fix compilation error

### DIFF
--- a/MoonRunner/Controller/ViewController/NewRunViewController.m
+++ b/MoonRunner/Controller/ViewController/NewRunViewController.m
@@ -248,7 +248,7 @@ static NSString * const detailSegueName = @"NewRunDetails";
         
         NSTimeInterval howRecent = [eventDate timeIntervalSinceNow];
         
-        if (abs(howRecent) < 10.0 && newLocation.horizontalAccuracy < 20) {
+        if (fabs(howRecent) < 10.0 && newLocation.horizontalAccuracy < 20) {
             
             // update distance
             if (self.locations.count > 0) {


### PR DESCRIPTION
Consider the following snippet:

NSTimeInterval howRecent = [eventDate timeIntervalSinceNow];
if (abs(howRecent) < 10.0) {

Here is NSTimeInterval's definition: typedef double NSTimeInterval;

Here is abs()'s signature: int abs(int) __pure2; 

Here is fabs()'s signature: extern double fabs(double);

In both Xcode 6.2 and 6.3, the above call to abs() was causing a compilation error due to the floating-point argument. I fixed the error by changing abs() to fabs(). This change seems logical given howRecent's floating-point type.
